### PR TITLE
Security Fixes - Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,7 @@ WORKDIR /usr/app/src
 COPY --chown=python:python src/* ./ 
 RUN [ -f ".env" ] || cp .env.docker .env
 
+USER python
+
 ENTRYPOINT ["gunicorn"  , "-b", "0.0.0.0:8080", "core_decision_flask_app:app"]
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl -f http://localhost:8080/health


### PR DESCRIPTION
## Context

Even if the RedHat base image is supposed to be free of problems, I noticed that there are some key issues related to its usage:

1. It's a fully-fledged operating system, so it has plenty of packages which we will **never** use
2. Since it's an operating system, the final size of the image is way bigger than what we could expect
3. Snyk throws different results on the scan than the RedHat website 

## Changes

Due to that, I decided to implement the following changes:

### Use a multi-stage build approach

There is no need of having the full operating system on the final image, even if we need some packages for compiling our dependencies. Due to that, we compile the dependencies of our project in a first stage within the context of a `venv` and then we use those already compiled dependencies for running the application.

### Use a custom non-root user

I know the RedHat image uses it's `1001` user by default, but I think it's better if we control in every moment which is the user that we're using and which permissions does it have over which directories.

Of course, using a root user isn't an option.

### Run the WSGI Server within the context of a `venv`

We don't want to use all the system-dependencies but just the ones that we explicitly installed and provided during the build step.

## Improves

|  | Old Image | New Image |
| ---- | ------------ | -------------|
| Size | 1.06 GB | 332 MB |
| Dependencies[^1] | 429 | 116 |
| Vulnerabilities[^1] | 805 | 48 | 

Also, the previous implemented cache capabilities will remain.

[^1]: `docker scan [IMAGE]`
